### PR TITLE
Improve regex support + minor bug fixes

### DIFF
--- a/app/src/main/java/com/ryansteckler/nlpunbounce/AlarmRegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/AlarmRegexFragment.java
@@ -23,18 +23,21 @@ import java.util.Set;
  * Created by rsteckler on 11/21/15.
  */
 public class AlarmRegexFragment extends BaseRegexFragment /* implements BaseDetailFragment.FragmentClearListener */ {
-
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
      * fragment (e.g. upon screen orientation changes).
      */
     public AlarmRegexFragment() {
         super();
-        this.mType = "alarm";
     }
 
     public static AlarmRegexFragment newInstance() {
         AlarmRegexFragment fragment = new AlarmRegexFragment();
         return fragment;
+    }
+
+    @Override
+    protected String getType() {
+        return "alarm";
     }
 }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/AlarmRegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/AlarmRegexFragment.java
@@ -22,101 +22,19 @@ import java.util.Set;
 /**
  * Created by rsteckler on 11/21/15.
  */
-public class AlarmRegexFragment extends android.app.ListFragment /* implements BaseDetailFragment.FragmentClearListener */ {
-
-    private RegexAdapter mAdapter;
+public class AlarmRegexFragment extends BaseRegexFragment /* implements BaseDetailFragment.FragmentClearListener */ {
 
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
      * fragment (e.g. upon screen orientation changes).
      */
     public AlarmRegexFragment() {
+        super();
+        this.mType = "alarm";
     }
 
     public static AlarmRegexFragment newInstance() {
         AlarmRegexFragment fragment = new AlarmRegexFragment();
         return fragment;
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        super.onCreateView(inflater, container, savedInstanceState);
-        View view = inflater.inflate(R.layout.fragment_stats, container, false);
-
-        return view;
-    }
-
-    @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        getActivity().getMenuInflater().inflate(R.menu.regex, menu);
-        super.onCreateOptionsMenu(menu, inflater);
-    }
-
-    public void reload() {
-        //Setup the list adapter
-        SharedPreferences prefs = getActivity().getSharedPreferences("com.ryansteckler.nlpunbounce_preferences", Context.MODE_WORLD_READABLE);
-        Set<String> sampleSet = new HashSet<String>();
-        Set<String> set = prefs.getStringSet("alarm_regex_set", sampleSet);
-        ArrayList<String> list = new ArrayList<String>(set);
-
-        // Create The Adapter with passing ArrayList as 3rd parameter
-        mAdapter = new RegexAdapter(getActivity(), list, "alarm");
-
-        // Sets The Adapter
-        setListAdapter(mAdapter);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        int id = item.getItemId();
-
-        if (id == R.id.action_new_custom) {
-            //Create a new custom alarm regex
-            DialogFragment dialog = RegexDialogFragment.newInstance("", "", "alarm");
-            dialog.setTargetFragment(this, 0);
-            dialog.show(getActivity().getFragmentManager(), "RegexDialog");
-        }
-        return super.onOptionsItemSelected(item);
-    }
-
-
-    @Override
-    public void onPrepareOptionsMenu(Menu menu) {
-        super.onPrepareOptionsMenu(menu);
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        ThemeHelper.onActivityCreateSetTheme(this.getActivity());
-
-        //Setup the list adapter
-        SharedPreferences prefs = getActivity().getSharedPreferences("com.ryansteckler.nlpunbounce_preferences", Context.MODE_WORLD_READABLE);
-        Set<String> sampleSet = new HashSet<String>();
-        Set<String> set = prefs.getStringSet("alarm_regex_set", sampleSet);
-        ArrayList<String> list = new ArrayList<String>(set);
-
-        // Create The Adapter with passing ArrayList as 3rd parameter
-        mAdapter = new RegexAdapter(getActivity(), list, "alarm");
-
-        // Sets The Adapter
-        setListAdapter(mAdapter);
-
-        setHasOptionsMenu(true);
-    }
-
-    @Override
-    public void onListItemClick(ListView l, final View v, int position, long id) {
-        super.onListItemClick(l, v, position, id);
-
-        //Switch to detail view.
-        //Open up the regex editor and prepop with this regex content.
-        String value = mAdapter.getItem(position);
-        String name = value.substring(0, value.indexOf("$$||$$"));
-        String seconds = value.substring(value.indexOf("$$||$$") + 6);
-        DialogFragment dialog = RegexDialogFragment.newInstance(name, seconds, "alarm");
-        dialog.setTargetFragment(this, 0);
-        dialog.show(getActivity().getFragmentManager(), "RegexDialog");
-
     }
 }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/AlarmRegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/AlarmRegexFragment.java
@@ -42,10 +42,11 @@ public class AlarmRegexFragment extends RegexFragment {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        ThemeHelper.onActivityCreateSetTheme(this.getActivity());
         if (getArguments() != null) {
             mTaskerMode = getArguments().getBoolean(ARG_TASKER_MODE);
         }
+
+        super.onCreate(savedInstanceState);
+        ThemeHelper.onActivityCreateSetTheme(this.getActivity());
     }
 }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/AlarmRegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/AlarmRegexFragment.java
@@ -1,28 +1,9 @@
 package com.ryansteckler.nlpunbounce;
 
-import android.app.DialogFragment;
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.os.Bundle;
-import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ListView;
-
-import com.ryansteckler.nlpunbounce.adapters.RegexAdapter;
-import com.ryansteckler.nlpunbounce.helpers.ThemeHelper;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
-
 /**
  * Created by rsteckler on 11/21/15.
  */
-public class AlarmRegexFragment extends BaseRegexFragment /* implements BaseDetailFragment.FragmentClearListener */ {
+public class AlarmRegexFragment extends RegexFragment /* implements BaseDetailFragment.FragmentClearListener */ {
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
      * fragment (e.g. upon screen orientation changes).

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/AlarmRegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/AlarmRegexFragment.java
@@ -1,9 +1,19 @@
 package com.ryansteckler.nlpunbounce;
 
+import android.os.Bundle;
+
+import com.ryansteckler.nlpunbounce.adapters.AlarmsAdapter;
+import com.ryansteckler.nlpunbounce.helpers.ThemeHelper;
+import com.ryansteckler.nlpunbounce.models.UnbounceStatsCollection;
+
 /**
  * Created by rsteckler on 11/21/15.
  */
-public class AlarmRegexFragment extends RegexFragment /* implements BaseDetailFragment.FragmentClearListener */ {
+public class AlarmRegexFragment extends RegexFragment {
+
+    private final static String ARG_TASKER_MODE = "taskerMode";
+    private boolean mTaskerMode = false;
+
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
      * fragment (e.g. upon screen orientation changes).
@@ -12,13 +22,30 @@ public class AlarmRegexFragment extends RegexFragment /* implements BaseDetailFr
         super();
     }
 
-    public static AlarmRegexFragment newInstance() {
+    public static AlarmRegexFragment newInstance() { return newInstance(false); }
+
+    public static AlarmRegexFragment newInstance(boolean taskerMode) {
         AlarmRegexFragment fragment = new AlarmRegexFragment();
+        Bundle args = new Bundle();
+        args.putBoolean(ARG_TASKER_MODE, taskerMode);
+        fragment.setArguments(args);
         return fragment;
     }
 
     @Override
     protected String getType() {
         return "alarm";
+    }
+
+    @Override
+    protected boolean getTaskerMode() { return mTaskerMode; }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ThemeHelper.onActivityCreateSetTheme(this.getActivity());
+        if (getArguments() != null) {
+            mTaskerMode = getArguments().getBoolean(ARG_TASKER_MODE);
+        }
     }
 }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/AlarmsFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/AlarmsFragment.java
@@ -82,6 +82,9 @@ public class AlarmsFragment extends ListFragment implements AlarmDetailFragment.
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        // Prevent menu items from crossing fragments
+        menu.clear();
+
         getActivity().getMenuInflater().inflate(R.menu.list, menu);
         SearchView searchView = (SearchView) menu.findItem(R.id.action_search).getActionView();
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/BaseDetailFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/BaseDetailFragment.java
@@ -126,18 +126,20 @@ public abstract class BaseDetailFragment extends Fragment {
         });
 
         TextView resetButton = (TextView) view.findViewById(R.id.buttonResetStats);
-        resetButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View resetView) {
-                //Reset stats
-                UnbounceStatsCollection stats = UnbounceStatsCollection.getInstance();
-                stats.resetStats(getActivity(), mStat.getName());
-                loadStatsFromSource(view);
-                if (mClearListener != null) {
-                    mClearListener.onCleared();
+        if (resetButton != null) {
+            resetButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View resetView) {
+                    //Reset stats
+                    UnbounceStatsCollection stats = UnbounceStatsCollection.getInstance();
+                    stats.resetStats(getActivity(), mStat.getName());
+                    loadStatsFromSource(view);
+                    if (mClearListener != null) {
+                        mClearListener.onCleared();
+                    }
                 }
-            }
-        });
+            });
+        }
 
         TextView description = (TextView) view.findViewById(R.id.textViewDescription);
         String descriptionText = EventLookup.getDescription(getActivity(), mStat.getName());

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/BaseRegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/BaseRegexFragment.java
@@ -1,8 +1,11 @@
 package com.ryansteckler.nlpunbounce;
 
-import android.app.DialogFragment;
+import android.app.Fragment;
+import android.app.FragmentManager;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.graphics.Point;
+import android.graphics.Rect;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -13,18 +16,23 @@ import android.view.ViewGroup;
 import android.widget.ListView;
 
 import com.ryansteckler.nlpunbounce.adapters.RegexAdapter;
+import com.ryansteckler.nlpunbounce.helpers.LogHelper;
 import com.ryansteckler.nlpunbounce.helpers.ThemeHelper;
+import com.ryansteckler.nlpunbounce.models.AlarmStats;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
-public class BaseRegexFragment extends android.app.ListFragment /* implements BaseDetailFragment.FragmentClearListener */ {
+public abstract class BaseRegexFragment extends android.app.ListFragment implements AlarmDetailFragment.FragmentClearListener {
 
+    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+    protected final static String ARG_TYPE = "type";
     protected static final String PREF_SET_TEMPLATE = "%1$s_regex_set";
 
-    protected RegexAdapter mAdapter;
-    protected String mType;
+    private RegexAdapter mAdapter;
+    private boolean mReloadOnShow = false;
+    private boolean mTaskerMode = false;
 
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
@@ -33,11 +41,7 @@ public class BaseRegexFragment extends android.app.ListFragment /* implements Ba
     public BaseRegexFragment() {
     }
 
-    protected static BaseRegexFragment newInstance(String type) {
-        BaseRegexFragment fragment = new BaseRegexFragment();
-        fragment.mType = type;
-        return fragment;
-    }
+    protected abstract String getType();
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -57,11 +61,11 @@ public class BaseRegexFragment extends android.app.ListFragment /* implements Ba
         //Setup the list adapter
         SharedPreferences prefs = getActivity().getSharedPreferences("com.ryansteckler.nlpunbounce_preferences", Context.MODE_WORLD_READABLE);
         Set<String> sampleSet = new HashSet<String>();
-        Set<String> set = prefs.getStringSet(String.format(PREF_SET_TEMPLATE, mType), sampleSet);
+        Set<String> set = prefs.getStringSet(String.format(PREF_SET_TEMPLATE, getType()), sampleSet);
         ArrayList<String> list = new ArrayList<String>(set);
 
         // Create The Adapter with passing ArrayList as 3rd parameter
-        mAdapter = new RegexAdapter(getActivity(), list, mType);
+        mAdapter = new RegexAdapter(getActivity(), list, getType());
 
         // Sets The Adapter
         setListAdapter(mAdapter);
@@ -73,9 +77,10 @@ public class BaseRegexFragment extends android.app.ListFragment /* implements Ba
 
         if (id == R.id.action_new_custom) {
             //Create a new custom alarm regex
-            DialogFragment dialog = RegexDialogFragment.newInstance("", "", mType);
-            dialog.setTargetFragment(this, 0);
-            dialog.show(getActivity().getFragmentManager(), "RegexDialog");
+            //Fragment fragment = RegexDialogFragment.newInstance("", "", "", mType);
+            //fragment.setTargetFragment(this, 0);
+            switchToDetail(0, "", "", "");
+            //fragment.show(getActivity().getFragmentManager(), "RegexDialog");
         }
         return super.onOptionsItemSelected(item);
     }
@@ -94,11 +99,11 @@ public class BaseRegexFragment extends android.app.ListFragment /* implements Ba
         //Setup the list adapter
         SharedPreferences prefs = getActivity().getSharedPreferences("com.ryansteckler.nlpunbounce_preferences", Context.MODE_WORLD_READABLE);
         Set<String> sampleSet = new HashSet<String>();
-        Set<String> set = prefs.getStringSet(String.format(PREF_SET_TEMPLATE, mType), sampleSet);
+        Set<String> set = prefs.getStringSet(String.format(PREF_SET_TEMPLATE, getType()), sampleSet);
         ArrayList<String> list = new ArrayList<String>(set);
 
         // Create The Adapter with passing ArrayList as 3rd parameter
-        mAdapter = new RegexAdapter(getActivity(), list, mType);
+        mAdapter = new RegexAdapter(getActivity(), list, getType());
 
         // Sets The Adapter
         setListAdapter(mAdapter);
@@ -113,11 +118,66 @@ public class BaseRegexFragment extends android.app.ListFragment /* implements Ba
         //Switch to detail view.
         //Open up the regex editor and prepop with this regex content.
         String value = mAdapter.getItem(position);
-        String name = value.substring(0, value.indexOf("$$||$$"));
-        String seconds = value.substring(value.indexOf("$$||$$") + 6);
-        DialogFragment dialog = RegexDialogFragment.newInstance(name, seconds, mType);
-        dialog.setTargetFragment(this, 0);
-        dialog.show(getActivity().getFragmentManager(), "RegexDialog");
+        String[] values = value.split("\\$\\$\\|\\|\\$\\$");  // matches $$||$$
+        String name, seconds, enabled;
+        enabled = "enabled";
 
+        if (values.length < 2)
+            return;
+
+        name = values[0];
+        seconds = values[1];
+
+        if (values.length > 2)
+            enabled = values[2];
+
+        //Fragment fragment = RegexDialogFragment.newInstance(name, seconds, enabled, mType);
+        //fragment.setTargetFragment(this, 0);
+        //fragment.show(getActivity().getFragmentManager(), "RegexDialog");
+
+        //Switch to detail view.
+        switchToDetail(position, name, seconds, enabled);
+    }
+
+    private void switchToDetail(int position, String name, String seconds, String enabled) {
+        //We're going for an animation from the list item, expanding to take the entire screen.
+        //Start by getting the bounds of the current list item, as a starting point.
+        ListView list = (ListView) getActivity().findViewById(android.R.id.list);
+        View listItem = list.getChildAt(position - list.getFirstVisiblePosition());
+        if (listItem == null) {
+            LogHelper.defaultLog(getActivity(), "About to crash.  null item at position: " + position);
+        }
+        final Rect startBounds = new Rect();
+        listItem.getGlobalVisibleRect(startBounds);
+
+        //Now get the final bounds for the animation:  the same bounds as the parent list.
+        final Rect finalBounds = new Rect();
+        final Point globalOffset = new Point();
+        list.getGlobalVisibleRect(finalBounds, globalOffset);
+
+        //Offset both bounds because we aren't full-screen.
+        startBounds.offset(-globalOffset.x, -globalOffset.y);
+        finalBounds.offset(-globalOffset.x, -globalOffset.y);
+
+        //Spin up the new Detail fragment.  Dig the custom animations.  Also put it on the back stack
+        //so we can hit the back button and come back to the list.
+        FragmentManager fragmentManager = getFragmentManager();
+        RegexDialogFragment newFrag = (RegexDialogFragment) new RegexDialogFragment().newInstance(startBounds.top, finalBounds.top, startBounds.bottom, finalBounds.bottom, new AlarmStats("Regex", "Regex"), mTaskerMode,
+                name, seconds, enabled, getType());
+        //RegexDialogFragment newFrag = (RegexDialogFragment) new RegexDialogFragment().newInstance(name, seconds, enabled, mType);
+        newFrag.attachClearListener(this);
+        newFrag.setTargetFragment(this, 0);
+        fragmentManager.beginTransaction()
+                .setCustomAnimations(R.animator.expand_in, R.animator.noop, R.animator.noop, R.animator.expand_out)
+                .hide(this)
+                .add(R.id.container, newFrag, "regex_detail")
+                .addToBackStack(null)
+                .commit();
+
+    }
+
+    @Override
+    public void onCleared() {
+        mReloadOnShow = true;
     }
 }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/BaseRegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/BaseRegexFragment.java
@@ -1,0 +1,123 @@
+package com.ryansteckler.nlpunbounce;
+
+import android.app.DialogFragment;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ListView;
+
+import com.ryansteckler.nlpunbounce.adapters.RegexAdapter;
+import com.ryansteckler.nlpunbounce.helpers.ThemeHelper;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+public class BaseRegexFragment extends android.app.ListFragment /* implements BaseDetailFragment.FragmentClearListener */ {
+
+    protected static final String PREF_SET_TEMPLATE = "%1$s_regex_set";
+
+    protected RegexAdapter mAdapter;
+    protected String mType;
+
+    /**
+     * Mandatory empty constructor for the fragment manager to instantiate the
+     * fragment (e.g. upon screen orientation changes).
+     */
+    public BaseRegexFragment() {
+    }
+
+    protected static BaseRegexFragment newInstance(String type) {
+        BaseRegexFragment fragment = new BaseRegexFragment();
+        fragment.mType = type;
+        return fragment;
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        super.onCreateView(inflater, container, savedInstanceState);
+        View view = inflater.inflate(R.layout.fragment_stats, container, false);
+
+        return view;
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        getActivity().getMenuInflater().inflate(R.menu.regex, menu);
+        super.onCreateOptionsMenu(menu, inflater);
+    }
+
+    public void reload() {
+        //Setup the list adapter
+        SharedPreferences prefs = getActivity().getSharedPreferences("com.ryansteckler.nlpunbounce_preferences", Context.MODE_WORLD_READABLE);
+        Set<String> sampleSet = new HashSet<String>();
+        Set<String> set = prefs.getStringSet(String.format(PREF_SET_TEMPLATE, mType), sampleSet);
+        ArrayList<String> list = new ArrayList<String>(set);
+
+        // Create The Adapter with passing ArrayList as 3rd parameter
+        mAdapter = new RegexAdapter(getActivity(), list, mType);
+
+        // Sets The Adapter
+        setListAdapter(mAdapter);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        int id = item.getItemId();
+
+        if (id == R.id.action_new_custom) {
+            //Create a new custom alarm regex
+            DialogFragment dialog = RegexDialogFragment.newInstance("", "", mType);
+            dialog.setTargetFragment(this, 0);
+            dialog.show(getActivity().getFragmentManager(), "RegexDialog");
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ThemeHelper.onActivityCreateSetTheme(this.getActivity());
+
+        //Setup the list adapter
+        SharedPreferences prefs = getActivity().getSharedPreferences("com.ryansteckler.nlpunbounce_preferences", Context.MODE_WORLD_READABLE);
+        Set<String> sampleSet = new HashSet<String>();
+        Set<String> set = prefs.getStringSet(String.format(PREF_SET_TEMPLATE, mType), sampleSet);
+        ArrayList<String> list = new ArrayList<String>(set);
+
+        // Create The Adapter with passing ArrayList as 3rd parameter
+        mAdapter = new RegexAdapter(getActivity(), list, mType);
+
+        // Sets The Adapter
+        setListAdapter(mAdapter);
+
+        setHasOptionsMenu(true);
+    }
+
+    @Override
+    public void onListItemClick(ListView l, final View v, int position, long id) {
+        super.onListItemClick(l, v, position, id);
+
+        //Switch to detail view.
+        //Open up the regex editor and prepop with this regex content.
+        String value = mAdapter.getItem(position);
+        String name = value.substring(0, value.indexOf("$$||$$"));
+        String seconds = value.substring(value.indexOf("$$||$$") + 6);
+        DialogFragment dialog = RegexDialogFragment.newInstance(name, seconds, mType);
+        dialog.setTargetFragment(this, 0);
+        dialog.show(getActivity().getFragmentManager(), "RegexDialog");
+
+    }
+}

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/HomeFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/HomeFragment.java
@@ -920,6 +920,9 @@ public class HomeFragment extends Fragment  {
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        // Prevent menu items from crossing fragments
+        menu.clear();
+
         getActivity().getMenuInflater().inflate(R.menu.home, menu);
         super.onCreateOptionsMenu(menu, inflater);
     }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/MaterialSettingsActivity.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/MaterialSettingsActivity.java
@@ -31,6 +31,7 @@ public class MaterialSettingsActivity extends Activity
         BaseDetailFragment.FragmentInteractionListener,
         HomeFragment.OnFragmentInteractionListener,
         AlarmsFragment.OnFragmentInteractionListener,
+        RegexFragment.OnFragmentInteractionListener,
         ServicesFragment.OnFragmentInteractionListener
     {
 
@@ -340,4 +341,15 @@ public class MaterialSettingsActivity extends Activity
             //Do nothing because we're not in Tasker mode.
 
         }
+
+    @Override
+    public void onRegexSetTitle(String title) {
+        mTitle = title;
+        restoreActionBar();
     }
+
+    @Override
+    public void onRegexSetTaskerTitle(String title) {
+        //Do nothing because we're not in Tasker mode.
+    }
+}

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/RegexDetailFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/RegexDetailFragment.java
@@ -302,7 +302,7 @@ public class RegexDetailFragment extends BaseDetailFragment {
                         // check if this regex already exists
                         for (Iterator<String> i = set.iterator(); i.hasNext();) {
                             String str = i.next();
-                            if (str.startsWith(mDefaultValue)) {
+                            if (str.startsWith(mDefaultValue + "$$||$$")) {
                                 textView.setError("Duplicate regex");
                                 return true;
                             }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/RegexDetailFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/RegexDetailFragment.java
@@ -26,6 +26,7 @@ import com.ryansteckler.nlpunbounce.models.UnbounceStatsCollection;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -68,6 +69,19 @@ public class RegexDetailFragment extends BaseDetailFragment {
         f.setArguments(args);
 
         return f;
+    }
+
+    @Override
+    public String getName() {
+        return mDefaultValue;
+    }
+
+    public long getSeconds() {
+        try {
+            return Long.parseLong(mDefaultSeconds);
+        } catch (NumberFormatException ex) {
+            return 240;
+        }
     }
 
     @Override
@@ -251,7 +265,7 @@ public class RegexDetailFragment extends BaseDetailFragment {
         try {
             String prevBlockName = mDefaultValue + "$$||$$" + mDefaultSeconds + "$$||$$" + mEnabled;
             boolean regexValid = true;
-            long seconds = Long.parseLong(mDefaultSeconds);
+            boolean regexChanged = false;
             if (edit.getId() == R.id.editRegexSeconds) {
                 mDefaultSeconds = Long.toString(Long.parseLong(textView.getText().toString()));
             } else if (edit.getId() == R.id.editRegex) {
@@ -261,6 +275,7 @@ public class RegexDetailFragment extends BaseDetailFragment {
                     regexValid = false;
                 }
                 if (regexValid) {
+                    regexChanged = true;
                     mDefaultValue = textView.getText().toString();
                     TextView description = (TextView) getView().findViewById(R.id.textViewDescription);
                     description.setText(getDescriptionText(mDefaultValue));
@@ -283,6 +298,17 @@ public class RegexDetailFragment extends BaseDetailFragment {
                 Set<String> sampleSet = new HashSet<String>();
                 Set<String> set = new HashSet<String>(prefs.getStringSet(mDefaultSetName + "_regex_set", sampleSet));
                 if (!TextUtils.isEmpty(mDefaultValue)) {
+                    if (regexChanged) {
+                        // check if this regex already exists
+                        for (Iterator<String> i = set.iterator(); i.hasNext();) {
+                            String str = i.next();
+                            if (str.startsWith(mDefaultValue)) {
+                                textView.setError("Duplicate regex");
+                                return true;
+                            }
+                        }
+                    }
+
                     set.remove(prevBlockName);
                     set.add(blockName);
                 }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/RegexDetailFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/RegexDetailFragment.java
@@ -54,7 +54,6 @@ public class RegexDetailFragment extends BaseDetailFragment {
                                                   String defaultValue, String defaultSeconds, String enabled, String defaultSetName) {
         RegexDetailFragment f = new RegexDetailFragment();
 
-        // Supply num input as an argument.
         Bundle args = new Bundle();
         args.putInt(ARG_START_TOP, startTop);
         args.putInt(ARG_FINAL_TOP, finalTop);
@@ -125,7 +124,7 @@ public class RegexDetailFragment extends BaseDetailFragment {
         panel.setAlpha(b ? 1 : (float) .4);
 
         TextView textView = (TextView) getView().findViewById(R.id.editRegex);
-        textView.setEnabled(b);
+        textView.setEnabled(!mTaskerMode && b);
         textView.clearFocus();
         panel = (View)getView().findViewById(R.id.settingsPanelRegex);
         panel.setBackgroundDrawable(backgroundColor);
@@ -254,7 +253,7 @@ public class RegexDetailFragment extends BaseDetailFragment {
         panel.setBackgroundDrawable(backgroundColor);
         panel.setAlpha(enabled ? 1 : (float) .4);
 
-        getView().findViewById(R.id.editRegex).setEnabled(onOff.isChecked());
+        getView().findViewById(R.id.editRegex).setEnabled(!mTaskerMode && onOff.isChecked());
         panel = (View)getView().findViewById(R.id.settingsPanelRegex);
         panel.setBackgroundDrawable(backgroundColor);
         panel.setAlpha(enabled ? 1 : (float) .4);

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/RegexDialogFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/RegexDialogFragment.java
@@ -1,42 +1,125 @@
 package com.ryansteckler.nlpunbounce;
 
-import android.app.AlertDialog;
-import android.app.Dialog;
 import android.app.Fragment;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.text.InputType;
+import android.text.TextUtils;
+import android.util.TypedValue;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
-import android.widget.LinearLayout;
+import android.widget.Switch;
 import android.widget.TextView;
 
+import com.ryansteckler.nlpunbounce.models.BaseStats;
+import com.ryansteckler.nlpunbounce.models.UnbounceStatsCollection;
+
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
  * Created by rsteckler on 11/10/15.
  */
-public class RegexDialogFragment  extends android.app.DialogFragment{
+public class RegexDialogFragment  extends BaseDetailFragment {
 
-    String mDefaultValue = "";
-    String mDefaultSeconds = "";
-    String mDefaultSetName = "wakelock";
+    private String mDefaultValue = "";
+    private String mDefaultSeconds = "240";
+    private String mDefaultSetName = "wakelock";
+    private String mEnabled = "enabled";
 
-    public static RegexDialogFragment newInstance(String defaultValue, String defaultSeconds, String defaultSetName) {
+    @Override
+    public RegexDialogFragment newInstance() {
+        return new RegexDialogFragment();
+    }
+
+    public RegexDialogFragment() {
+        // Required empty public constructor
+    }
+
+    public static RegexDialogFragment newInstance(int startTop, int finalTop, int startBottom, int finalBottom, BaseStats stat, boolean taskerMode,
+                                                  String defaultValue, String defaultSeconds, String enabled, String defaultSetName) {
         RegexDialogFragment f = new RegexDialogFragment();
 
         // Supply num input as an argument.
         Bundle args = new Bundle();
-        args.putString("defaultValue", defaultValue);
-        args.putString("defaultSeconds", defaultSeconds);
-        args.putString("defaultSetName", defaultSetName);
+        args.putInt(ARG_START_TOP, startTop);
+        args.putInt(ARG_FINAL_TOP, finalTop);
+        args.putInt(ARG_START_BOTTOM, startBottom);
+        args.putInt(ARG_FINAL_BOTTOM, finalBottom);
+        args.putSerializable(ARG_CUR_STAT, stat);
+        args.putBoolean(ARG_TASKER_MODE, taskerMode);
+        args.putString("defaultValue", TextUtils.isEmpty(defaultValue) ? "" : defaultValue);
+        args.putString("defaultSeconds", TextUtils.isEmpty(defaultSeconds) ? "240" : defaultSeconds);
+        args.putString("defaultSetName", TextUtils.isEmpty(defaultSetName) ? "wakelock" : defaultSetName);
+        args.putString("defaultEnabled", TextUtils.isEmpty(enabled) ? "enabled" : enabled);
         f.setArguments(args);
 
         return f;
     }
+
+    @Override
+    protected void warnUnknown(final Switch onOff) {
+        onOff.toggle();
+        updateEnabled(onOff.isChecked());
+    }
+
+    @Override
+    protected void updateEnabled(boolean b) {
+        String prevBlockName = mDefaultValue + "$$||$$" + mDefaultSeconds + "$$||$$" + mEnabled;
+        mEnabled = (b) ? "enabled" : "disabled";
+        String blockName = mDefaultValue + "$$||$$" + mDefaultSeconds + "$$||$$" + mEnabled;
+
+        if (!mTaskerMode) {
+            SharedPreferences prefs = getActivity().getSharedPreferences("com.ryansteckler.nlpunbounce" + "_preferences", Context.MODE_WORLD_READABLE);
+            Set<String> sampleSet = new HashSet<String>();
+            Set<String> set = new HashSet<String>(prefs.getStringSet(mDefaultSetName + "_regex_set", sampleSet));
+            if (!TextUtils.isEmpty(mDefaultValue)) {
+                set.remove(prevBlockName);
+                set.add(blockName);
+            }
+
+            SharedPreferences.Editor editor = prefs.edit();
+            editor.putStringSet(mDefaultSetName + "_regex_set", set);
+            editor.apply();
+        }
+
+        //Enable or disable the seconds setting.
+        getView().findViewById(R.id.editRegexSeconds).setEnabled(b);
+        View panel = (View)getView().findViewById(R.id.settingsPanelSeconds);
+        TypedValue backgroundValue = new TypedValue();
+        Resources.Theme theme = getActivity().getTheme();
+        int resId = b ? R.attr.background_panel_enabled : R.attr.background_panel_disabled;
+        boolean success = theme.resolveAttribute(resId, backgroundValue, true);
+        Drawable backgroundColor = getResources().getDrawable(R.drawable.header_background_dark);
+        if (success) {
+            backgroundColor = getResources().getDrawable(backgroundValue.resourceId);
+        }
+        panel.setBackgroundDrawable(backgroundColor);
+        panel.setAlpha(b ? 1 : (float) .4);
+
+        getView().findViewById(R.id.editRegex).setEnabled(b);
+        panel = (View)getView().findViewById(R.id.settingsPanelRegex);
+        panel.setBackgroundDrawable(backgroundColor);
+        panel.setAlpha(b ? 1 : (float) .4);
+
+        if (mClearListener != null)
+        {
+            mClearListener.onCleared();
+        }
+    }
+
+    @Override
+    protected void loadStatsFromSource(View view) { /* empty */ }
 
     @Override
     public void onCreate(Bundle savedInstance) {
@@ -44,100 +127,189 @@ public class RegexDialogFragment  extends android.app.DialogFragment{
         mDefaultValue = "";
         mDefaultSeconds = "240";
         mDefaultSetName = "wakelock";
+        mEnabled = "enabled";
         if (savedInstance != null) {
             mDefaultValue = savedInstance.getString("defaultValue");
             mDefaultSeconds = savedInstance.getString("defaultSeconds");
             mDefaultSetName = savedInstance.getString("defaultSetName");
+            mEnabled = savedInstance.getString("defaultEnabled");
         } else if (getArguments() != null) {
             mDefaultValue = getArguments().getString("defaultValue");
             mDefaultSeconds = getArguments().getString("defaultSeconds");
             mDefaultSetName = getArguments().getString("defaultSetName");
+            mEnabled = getArguments().getString("defaultEnabled");
         }
     }
 
+    private String getDescriptionText(String regex) {
+        ArrayList<BaseStats> events;
+        if (mDefaultSetName.equals("wakelock")) {
+            events = UnbounceStatsCollection.getInstance().toWakelockArrayList(getView().getContext());
+        } else if (mDefaultSetName.equals("alarm")) {
+            events = UnbounceStatsCollection.getInstance().toAlarmArrayList(getView().getContext());
+        } else {
+            return "Description unavailable";
+        }
+
+        Set<String> matchingEvents = new HashSet<>();
+
+        for (BaseStats event : events) {
+            String eventName = event.getName();
+            if (eventName.matches(regex))
+                matchingEvents.add(eventName);
+        }
+
+        String descriptionText = getResources().getString(R.string.desc_regex_unknown);
+        if (matchingEvents.size() > 0)
+            descriptionText = String.format(getResources().getString(R.string.desc_regex), matchingEvents.size(), events.size())
+                + "\n\n" + TextUtils.join("\n", matchingEvents);
+        return descriptionText;
+    }
+
     @Override
-    public Dialog onCreateDialog(Bundle savedInstanceState) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setTitle("Custom Regex");
+    public void onViewCreated(final View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
 
-        final TextView regexLabel = new TextView(getActivity());
-        regexLabel.setText("Enter the Regex to match");
-        int paddingE = getResources().getDimensionPixelOffset(R.dimen.card_external_padding);
-        int paddingI = getResources().getDimensionPixelOffset(R.dimen.card_internal_padding);
-        regexLabel.setPadding(paddingI, paddingI, paddingI, 0);
+        TextView description = (TextView) view.findViewById(R.id.textViewDescription);
+        description.setText(getDescriptionText(mDefaultValue));
 
-        // Use an EditText view to get user input.
-        final EditText input = new EditText(getActivity());
-        input.setId(0);
-        input.setSingleLine(true);
-        input.setPadding(paddingI, 0, paddingI, 0);
+        SharedPreferences prefs = getActivity().getSharedPreferences(RegexDialogFragment.class.getPackage().getName() + "_preferences", Context.MODE_WORLD_READABLE);
 
-        final TextView secondsLabel = new TextView(getActivity());
-        secondsLabel.setText("Enter the interval in seconds");
-        secondsLabel.setPadding(paddingI, paddingE, paddingI, 0);
+        final EditText editSeconds = (EditText) view.findViewById(R.id.editRegexSeconds);
 
-        final EditText secondsEdit = new EditText(getActivity());
-        secondsEdit.setSingleLine(true);
-        secondsEdit.setInputType(InputType.TYPE_CLASS_NUMBER);
-        secondsEdit.setPadding(paddingI, 0, paddingI, paddingI);
-
-        LinearLayout parentView = new LinearLayout(getActivity());
-        parentView.setOrientation(LinearLayout.VERTICAL);
-        ViewGroup.LayoutParams LLParams = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
-        parentView.setLayoutParams(LLParams);
-        parentView.addView(regexLabel);
-        parentView.addView(input);
-        parentView.addView(secondsLabel);
-        parentView.addView(secondsEdit);
-
-        builder.setView(parentView);
-
-        if (mDefaultValue != null) {
-            input.setText(mDefaultValue);
-        }
-
-        if (mDefaultSeconds != null) {
-            secondsEdit.setText(mDefaultSeconds.toString());
-        }
-
-        builder.setPositiveButton("Ok", new DialogInterface.OnClickListener() {
-
+        editSeconds.setText(String.valueOf(Long.getLong(mDefaultSeconds, 240)));
+        editSeconds.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             @Override
-            public void onClick(DialogInterface dialog, int whichButton) {
-                String value = input.getText().toString();
-                String seconds = secondsEdit.getText().toString();
-                //Set value in Prefs and reload them for the list.
-                SharedPreferences prefs = getActivity().getSharedPreferences("com.ryansteckler.nlpunbounce_preferences", Context.MODE_WORLD_READABLE);
+            public boolean onEditorAction(TextView textView, int i, KeyEvent keyEvent) {
+                if (i == EditorInfo.IME_ACTION_DONE) {
+                    return handleTextChange(textView, editSeconds);
+                }
+                return false;
+            }
+        });
+        editSeconds.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View view, boolean b) {
+                if (!b) {
+                    handleTextChange((TextView) view, editSeconds);
+                }
+            }
+        });
+
+        final EditText editRegex = (EditText) view.findViewById(R.id.editRegex);
+
+        editRegex.setText(mDefaultValue);
+        editRegex.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView textView, int i, KeyEvent keyEvent) {
+                if (i == EditorInfo.IME_ACTION_DONE) {
+                    return handleTextChange(textView, editSeconds);
+                }
+                return false;
+            }
+        });
+        editRegex.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View view, boolean b) {
+                if (!b) {
+                    handleTextChange((TextView) view, editSeconds);
+                }
+            }
+        });
+
+        final Switch onOff = (Switch) view.findViewById(R.id.switchStat);
+        boolean enabled = mEnabled.equals("enabled");
+        onOff.setChecked(enabled);
+
+        getView().findViewById(R.id.editRegexSeconds).setEnabled(onOff.isChecked());
+
+        View panel = (View)getView().findViewById(R.id.settingsPanelSeconds);
+        TypedValue backgroundValue = new TypedValue();
+        Resources.Theme theme = getActivity().getTheme();
+        int resId = enabled ? R.attr.background_panel_enabled : R.attr.background_panel_disabled;
+        boolean success = theme.resolveAttribute(resId, backgroundValue, true);
+        Drawable backgroundColor = getResources().getDrawable(R.drawable.header_background_dark);
+        if (success) {
+            backgroundColor = getResources().getDrawable(backgroundValue.resourceId);
+        }
+        panel.setBackgroundDrawable(backgroundColor);
+        panel.setAlpha(enabled ? 1 : (float) .4);
+
+        getView().findViewById(R.id.editRegex).setEnabled(onOff.isChecked());
+        panel = (View)getView().findViewById(R.id.settingsPanelRegex);
+        panel.setBackgroundDrawable(backgroundColor);
+        panel.setAlpha(enabled ? 1 : (float) .4);
+
+    }
+
+    private boolean handleTextChange(TextView textView, EditText edit) {
+        try {
+            String prevBlockName = mDefaultValue + "$$||$$" + mDefaultSeconds + "$$||$$" + mEnabled;
+            long seconds = Long.parseLong(mDefaultSeconds);
+            if (textView.getId() == R.id.editRegexSeconds) {
+                mDefaultSeconds = Long.toString(Long.parseLong(textView.getText().toString()));
+            } else if (textView.getId() == R.id.editRegex) {
+                mDefaultValue = textView.getText().toString();
+                TextView description = (TextView) getView().findViewById(R.id.textViewDescription);
+                description.setText(getDescriptionText(mDefaultValue));
+
+                if (mClearListener != null)
+                {
+                    mClearListener.onCleared();
+                }
+            }
+            String blockName = mDefaultValue + "$$||$$" + mDefaultSeconds + "$$||$$" + mEnabled;
+
+            if (!mTaskerMode) {
+                SharedPreferences prefs = getActivity().getSharedPreferences(RegexDialogFragment.class.getPackage().getName() + "_preferences", Context.MODE_WORLD_READABLE);
                 Set<String> sampleSet = new HashSet<String>();
                 Set<String> set = new HashSet<String>(prefs.getStringSet(mDefaultSetName + "_regex_set", sampleSet));
-                if (mDefaultValue != "" ) {
-                    set.remove(mDefaultValue + "$$||$$" + mDefaultSeconds);
+                if (!TextUtils.isEmpty(mDefaultValue)) {
+                    set.remove(prevBlockName);
+                    set.add(blockName);
                 }
-                set.add(value + "$$||$$" + seconds);
 
-                SharedPreferences.Editor edit = prefs.edit();
-                edit.putStringSet(mDefaultSetName + "_regex_set", set);
-                edit.commit();
-                Fragment regexFrag = getTargetFragment();
-                if (regexFrag instanceof WakelockRegexFragment) {
-                    ((WakelockRegexFragment) (regexFrag)).reload();
-                } else if (regexFrag instanceof AlarmRegexFragment) {
-                    ((AlarmRegexFragment) (regexFrag)).reload();
-                }
-                return;
+                SharedPreferences.Editor editor = prefs.edit();
+                editor.putStringSet(mDefaultSetName + "_regex_set", set);
+                editor.apply();
             }
-        });
+            textView.clearFocus();
+            // hide virtual keyboard
+            InputMethodManager imm = (InputMethodManager)getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.hideSoftInputFromWindow(edit.getWindowToken(), 0);
 
-        builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+            Fragment regexFrag = getTargetFragment();
+            if (regexFrag instanceof BaseRegexFragment)
+                ((BaseRegexFragment) (regexFrag)).reload();
 
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                return;
-            }
-        });
+            return true;
 
-        return builder.create();
+        } catch (NumberFormatException nfe)
+        {
+            //Not a number.  Android let us down.
+        }
+        return false;
+    }
 
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        View view = inflater.inflate(R.layout.fragment_regex_detail, container, false);
+        return view;
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        super.onCreateOptionsMenu(menu, inflater);
+        menu.clear();
+        //getActivity().getMenuInflater().inflate(R.menu.alarm_detail, menu);
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mListener = null;
     }
 
 }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/RegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/RegexFragment.java
@@ -1,5 +1,6 @@
 package com.ryansteckler.nlpunbounce;
 
+import android.app.Activity;
 import android.app.FragmentManager;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -57,7 +58,7 @@ public abstract class RegexFragment extends android.app.ListFragment implements 
         super.onViewCreated(view, savedInstanceState);
 
         if (mListener != null)
-            mListener.onRegexSetTitle(getResources().getString(R.string.title_regex));
+            mListener.onRegexSetTitle(getType().substring(0,1).toUpperCase() + getType().substring(1) + " " + getResources().getString(R.string.title_regex));
     }
 
     @Override
@@ -74,7 +75,7 @@ public abstract class RegexFragment extends android.app.ListFragment implements 
         ArrayList<String> list = new ArrayList<String>(set);
 
         // Create The Adapter with passing ArrayList as 3rd parameter
-        mAdapter = new RegexAdapter(getActivity(), list, getType());
+        mAdapter = new RegexAdapter(getActivity(), list, getType(), getTaskerMode());
 
         // Sets The Adapter
         setListAdapter(mAdapter);
@@ -156,7 +157,7 @@ public abstract class RegexFragment extends android.app.ListFragment implements 
         //Spin up the new Detail fragment.  Dig the custom animations.  Also put it on the back stack
         //so we can hit the back button and come back to the list.
         FragmentManager fragmentManager = getFragmentManager();
-        RegexDetailFragment newFrag = RegexDetailFragment.newInstance(startBounds.top, finalBounds.top, startBounds.bottom, finalBounds.bottom, new AlarmStats("Regex", "Regex"), getTaskerMode(),
+        RegexDetailFragment newFrag = RegexDetailFragment.newInstance(startBounds.top, finalBounds.top, startBounds.bottom, finalBounds.bottom, new AlarmStats(name, "Regex"), getTaskerMode(),
                 name, seconds, enabled, getType());
         newFrag.attachClearListener(this);
         fragmentManager.beginTransaction()
@@ -174,7 +175,7 @@ public abstract class RegexFragment extends android.app.ListFragment implements 
         //Remember the scroll pos so we can reinstate it
         if (!hidden) {
             if (mListener != null) {
-                mListener.onRegexSetTitle(getResources().getString(R.string.title_regex));
+                mListener.onRegexSetTitle(getType().substring(0,1).toUpperCase() + getType().substring(1) + " " + getResources().getString(R.string.title_regex));
                 if ("alarm".equals(getType())) {
                     mListener.onRegexSetTaskerTitle(getResources().getString(R.string.tasker_choose_alarm_regex));
                 } else {
@@ -192,6 +193,17 @@ public abstract class RegexFragment extends android.app.ListFragment implements 
     @Override
     public void onCleared() {
         mReloadOnShow = true;
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        try {
+            mListener = (OnFragmentInteractionListener) activity;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(activity.toString()
+                    + " must implement OnFragmentInteractionListener");
+        }
     }
 
     @Override

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/RegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/RegexFragment.java
@@ -64,6 +64,9 @@ public abstract class RegexFragment extends android.app.ListFragment implements 
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        // Prevent menu items from crossing fragments
+        menu.clear();
+
         getActivity().getMenuInflater().inflate(R.menu.regex, menu);
         super.onCreateOptionsMenu(menu, inflater);
     }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/RegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/RegexFragment.java
@@ -7,6 +7,7 @@ import android.content.SharedPreferences;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -87,10 +88,7 @@ public abstract class RegexFragment extends android.app.ListFragment implements 
 
         if (id == R.id.action_new_custom) {
             //Create a new custom alarm regex
-            //Fragment fragment = RegexDetailFragment.newInstance("", "", "", mType);
-            //fragment.setTargetFragment(this, 0);
             switchToDetail(0, "", "", "");
-            //fragment.show(getActivity().getFragmentManager(), "RegexDialog");
         }
         return super.onOptionsItemSelected(item);
     }
@@ -157,7 +155,8 @@ public abstract class RegexFragment extends android.app.ListFragment implements 
         //Spin up the new Detail fragment.  Dig the custom animations.  Also put it on the back stack
         //so we can hit the back button and come back to the list.
         FragmentManager fragmentManager = getFragmentManager();
-        RegexDetailFragment newFrag = RegexDetailFragment.newInstance(startBounds.top, finalBounds.top, startBounds.bottom, finalBounds.bottom, new AlarmStats(name, "Regex"), getTaskerMode(),
+        String title = TextUtils.isEmpty(name) ? "New Regex" : name;
+        RegexDetailFragment newFrag = RegexDetailFragment.newInstance(startBounds.top, finalBounds.top, startBounds.bottom, finalBounds.bottom, new AlarmStats(title, "Regex"), getTaskerMode(),
                 name, seconds, enabled, getType());
         newFrag.attachClearListener(this);
         fragmentManager.beginTransaction()

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/ServicesFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/ServicesFragment.java
@@ -88,6 +88,11 @@ public class ServicesFragment extends ListFragment implements ServiceDetailFragm
                 return true;
             }
         });
+
+        // Don't support regex for services, so disable the button
+        menu.findItem(R.id.action_new_custom).setVisible(false)
+                .setEnabled(false);
+
         super.onCreateOptionsMenu(menu, inflater);
     }
 

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/ServicesFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/ServicesFragment.java
@@ -73,6 +73,9 @@ public class ServicesFragment extends ListFragment implements ServiceDetailFragm
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        // Prevent menu items from crossing fragments
+        menu.clear();
+
         getActivity().getMenuInflater().inflate(R.menu.list, menu);
         SearchView searchView = (SearchView) menu.findItem(R.id.action_search).getActionView();
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/WakelockRegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/WakelockRegexFragment.java
@@ -44,11 +44,12 @@ public class WakelockRegexFragment extends RegexFragment {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        ThemeHelper.onActivityCreateSetTheme(this.getActivity());
         if (getArguments() != null) {
             mTaskerMode = getArguments().getBoolean(ARG_TASKER_MODE);
         }
+
+        super.onCreate(savedInstanceState);
+        ThemeHelper.onActivityCreateSetTheme(this.getActivity());
     }
 
 }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/WakelockRegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/WakelockRegexFragment.java
@@ -26,101 +26,19 @@ import java.util.Set;
  * Activities containing this fragment MUST implement the {OnFragmentInteractionListener}
  * interface.
  */
-public class WakelockRegexFragment extends android.app.ListFragment /* implements BaseDetailFragment.FragmentClearListener */ {
-
-    private RegexAdapter mAdapter;
+public class WakelockRegexFragment extends BaseRegexFragment {
 
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
      * fragment (e.g. upon screen orientation changes).
      */
     public WakelockRegexFragment() {
+        super();
+        this.mType = "wakelock";
     }
 
     public static WakelockRegexFragment newInstance() {
         WakelockRegexFragment fragment = new WakelockRegexFragment();
         return fragment;
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        super.onCreateView(inflater, container, savedInstanceState);
-        View view = inflater.inflate(R.layout.fragment_stats, container, false);
-
-        return view;
-    }
-
-    @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        getActivity().getMenuInflater().inflate(R.menu.regex, menu);
-        super.onCreateOptionsMenu(menu, inflater);
-    }
-
-    public void reload() {
-        //Setup the list adapter
-        SharedPreferences prefs = getActivity().getSharedPreferences("com.ryansteckler.nlpunbounce_preferences", Context.MODE_WORLD_READABLE);
-        Set<String> sampleSet = new HashSet<String>();
-        Set<String> set = prefs.getStringSet("wakelock_regex_set", sampleSet);
-        ArrayList<String> list = new ArrayList<String>(set);
-
-        // Create The Adapter with passing ArrayList as 3rd parameter
-        mAdapter = new RegexAdapter(getActivity(), list, "wakelock");
-
-        // Sets The Adapter
-        setListAdapter(mAdapter);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        int id = item.getItemId();
-
-        if (id == R.id.action_new_custom) {
-            //Create a new custom wakelock regex
-            DialogFragment dialog = RegexDialogFragment.newInstance("", "", "wakelock");
-            dialog.setTargetFragment(this, 0);
-            dialog.show(getActivity().getFragmentManager(), "RegexDialog");
-        }
-        return super.onOptionsItemSelected(item);
-    }
-
-
-    @Override
-    public void onPrepareOptionsMenu(Menu menu) {
-        super.onPrepareOptionsMenu(menu);
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        ThemeHelper.onActivityCreateSetTheme(this.getActivity());
-
-        //Setup the list adapter
-        SharedPreferences prefs = getActivity().getSharedPreferences("com.ryansteckler.nlpunbounce_preferences", Context.MODE_WORLD_READABLE);
-        Set<String> sampleSet = new HashSet<String>();
-        Set<String> set = prefs.getStringSet("wakelock_regex_set", sampleSet);
-        ArrayList<String> list = new ArrayList<String>(set);
-
-        // Create The Adapter with passing ArrayList as 3rd parameter
-        mAdapter = new RegexAdapter(getActivity(), list, "wakelock");
-
-        // Sets The Adapter
-        setListAdapter(mAdapter);
-
-        setHasOptionsMenu(true);
-    }
-
-    @Override
-    public void onListItemClick(ListView l, final View v, int position, long id) {
-        super.onListItemClick(l, v, position, id);
-
-        //Switch to detail view.
-        //Open up the regex editor and prepop with this regex content.
-        String value = mAdapter.getItem(position);
-        String name = value.substring(0, value.indexOf("$$||$$"));
-        String seconds = value.substring(value.indexOf("$$||$$") + 6);
-        DialogFragment dialog = RegexDialogFragment.newInstance(name, seconds, "wakelock");
-        dialog.setTargetFragment(this, 0);
-        dialog.show(getActivity().getFragmentManager(), "RegexDialog");
-
     }
 }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/WakelockRegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/WakelockRegexFragment.java
@@ -34,11 +34,17 @@ public class WakelockRegexFragment extends BaseRegexFragment {
      */
     public WakelockRegexFragment() {
         super();
-        this.mType = "wakelock";
     }
 
     public static WakelockRegexFragment newInstance() {
         WakelockRegexFragment fragment = new WakelockRegexFragment();
         return fragment;
     }
+
+    @Override
+    protected String getType() {
+        return "wakelock";
+    }
+
+
 }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/WakelockRegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/WakelockRegexFragment.java
@@ -1,5 +1,9 @@
 package com.ryansteckler.nlpunbounce;
 
+import android.os.Bundle;
+
+import com.ryansteckler.nlpunbounce.helpers.ThemeHelper;
+
 /**
  * A fragment representing a list of Items.
  * <p/>
@@ -9,6 +13,9 @@ package com.ryansteckler.nlpunbounce;
  */
 public class WakelockRegexFragment extends RegexFragment {
 
+    private final static String ARG_TASKER_MODE = "taskerMode";
+    private boolean mTaskerMode = false;
+
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
      * fragment (e.g. upon screen orientation changes).
@@ -17,8 +24,13 @@ public class WakelockRegexFragment extends RegexFragment {
         super();
     }
 
-    public static WakelockRegexFragment newInstance() {
+    public static WakelockRegexFragment newInstance() { return newInstance(false); }
+
+    public static WakelockRegexFragment newInstance(boolean taskerMode) {
         WakelockRegexFragment fragment = new WakelockRegexFragment();
+        Bundle args = new Bundle();
+        args.putBoolean(ARG_TASKER_MODE, taskerMode);
+        fragment.setArguments(args);
         return fragment;
     }
 
@@ -27,5 +39,16 @@ public class WakelockRegexFragment extends RegexFragment {
         return "wakelock";
     }
 
+    @Override
+    protected boolean getTaskerMode() { return mTaskerMode; }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ThemeHelper.onActivityCreateSetTheme(this.getActivity());
+        if (getArguments() != null) {
+            mTaskerMode = getArguments().getBoolean(ARG_TASKER_MODE);
+        }
+    }
 
 }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/WakelockRegexFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/WakelockRegexFragment.java
@@ -1,24 +1,5 @@
 package com.ryansteckler.nlpunbounce;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.os.Bundle;
-import android.app.DialogFragment;
-import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ListView;
-
-import com.ryansteckler.nlpunbounce.adapters.RegexAdapter;
-import com.ryansteckler.nlpunbounce.helpers.ThemeHelper;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
-
 /**
  * A fragment representing a list of Items.
  * <p/>
@@ -26,7 +7,7 @@ import java.util.Set;
  * Activities containing this fragment MUST implement the {OnFragmentInteractionListener}
  * interface.
  */
-public class WakelockRegexFragment extends BaseRegexFragment {
+public class WakelockRegexFragment extends RegexFragment {
 
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/WakelocksFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/WakelocksFragment.java
@@ -83,6 +83,9 @@ public class WakelocksFragment extends ListFragment implements BaseDetailFragmen
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        // Prevent menu items from crossing fragments
+        menu.clear();
+
         getActivity().getMenuInflater().inflate(R.menu.list, menu);
         SearchView searchView = (SearchView) menu.findItem(R.id.action_search).getActionView();
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/adapters/RegexAdapter.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/adapters/RegexAdapter.java
@@ -33,12 +33,14 @@ public class RegexAdapter extends ArrayAdapter<String> {
     private final ArrayList<String> list;
     private final Activity context;
     private final String mEntityName;
+    private final boolean mTaskerMode;
 
-    public RegexAdapter(Activity context, ArrayList<String> list, String entityName) {
+    public RegexAdapter(Activity context, ArrayList<String> list, String entityName, boolean taskerMode) {
         super(context, R.layout.fragment_regex_listitem, list);
         this.context = context;
         this.list = list;
         this.mEntityName = entityName;
+        this.mTaskerMode = taskerMode;
     }
 
     @Override
@@ -77,6 +79,8 @@ public class RegexAdapter extends ArrayAdapter<String> {
 
                 }
             });
+
+            button.setEnabled(!mTaskerMode);
         }
 
         TextView regexMatchText = (TextView) view.findViewById(R.id.regexMatchText);

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/adapters/RegexAdapter.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/adapters/RegexAdapter.java
@@ -3,6 +3,9 @@ package com.ryansteckler.nlpunbounce.adapters;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.graphics.Path;
+import android.text.Layout;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -10,9 +13,12 @@ import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.ryansteckler.nlpunbounce.R;
+import com.ryansteckler.nlpunbounce.models.BaseStats;
+import com.ryansteckler.nlpunbounce.models.UnbounceStatsCollection;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -72,6 +78,30 @@ public class RegexAdapter extends ArrayAdapter<String> {
                 }
             });
         }
+
+        LinearLayout regexMatchListView = (LinearLayout) view.findViewById(R.id.regexMatchList);
+        TextView regexMatchText = (TextView) view.findViewById(R.id.regexMatchText);
+        int matchingAlarmsCount = 0;
+        ArrayList<BaseStats> alarms = UnbounceStatsCollection.getInstance().toAlarmArrayList(null);
+        for (BaseStats alarm : alarms) {
+            String alarmName = alarm.getName();
+            if (alarmName.matches(text.getText().toString())) {
+                TextView tv = new TextView(view.getContext());
+                tv.setText(alarmName);
+                regexMatchListView.addView(tv);
+                matchingAlarmsCount++;
+
+                // for scrolling
+                tv.setLayoutParams(regexMatchText.getLayoutParams());
+                tv.setEllipsize(regexMatchText.getEllipsize());
+                tv.setSelected(true);
+                tv.setSingleLine(true);
+            }
+        }
+
+        regexMatchText.setText(String.format(context.getResources().getString(R.string.alarm_regex_matches),
+                matchingAlarmsCount, alarms.size()));
+
         return view;
     }
 

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/adapters/RegexAdapter.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/adapters/RegexAdapter.java
@@ -79,28 +79,20 @@ public class RegexAdapter extends ArrayAdapter<String> {
             });
         }
 
-        LinearLayout regexMatchListView = (LinearLayout) view.findViewById(R.id.regexMatchList);
         TextView regexMatchText = (TextView) view.findViewById(R.id.regexMatchText);
         int matchingAlarmsCount = 0;
         ArrayList<BaseStats> alarms = UnbounceStatsCollection.getInstance().toAlarmArrayList(null);
         for (BaseStats alarm : alarms) {
-            String alarmName = alarm.getName();
-            if (alarmName.matches(text.getText().toString())) {
-                TextView tv = new TextView(view.getContext());
-                tv.setText(alarmName);
-                regexMatchListView.addView(tv);
+            if (alarm.getName().matches(text.getText().toString()))
                 matchingAlarmsCount++;
-
-                // for scrolling
-                tv.setLayoutParams(regexMatchText.getLayoutParams());
-                tv.setEllipsize(regexMatchText.getEllipsize());
-                tv.setSelected(true);
-                tv.setSingleLine(true);
-            }
         }
 
-        regexMatchText.setText(String.format(context.getResources().getString(R.string.alarm_regex_matches),
-                matchingAlarmsCount, alarms.size()));
+        if (this.list.get(position).substring(this.list.get(position).lastIndexOf("$$||$$") + "$$||$$".length()).equals("disabled")) {
+            regexMatchText.setText(context.getResources().getString(R.string.regex_list_disabled));
+        } else {
+            regexMatchText.setText(String.format(context.getResources().getString(R.string.regex_list_enabled),
+                    matchingAlarmsCount, alarms.size()));
+        }
 
         return view;
     }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/hooks/Wakelocks.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/hooks/Wakelocks.java
@@ -435,11 +435,15 @@ public class Wakelocks implements IXposedHookLoadPackage {
             if (wakelockWildcards != null) {
                 //For each wildcard block
                 for (String wildcard : wakelockWildcards) {
-                    String regexToMatch = wildcard.substring(0, wildcard.indexOf("$$||$$"));
-                    if (wakeLockName.matches(wildcard)) {
+                    String[] values = wildcard.split("\\$\\$\\|\\|\\$\\$"); // matches $$||$$
+                    if (values.length < 2)
+                        continue;  // *should* never happen
+
+                    String regexToMatch = values[0];
+                    boolean disabled = values.length > 2 && "disabled".equals(values[2]);
+                    if (!disabled && wakeLockName.matches(regexToMatch)) {
                         block = true;
-                        overrideSeconds = Integer.parseInt(wildcard.substring(wildcard.indexOf("$$||$$") + 6));
-                        trackingWakelockName = wildcard;
+                        overrideSeconds = Integer.parseInt(values[1]);
                         debugLog("Regex set for Wakelock: " + wakeLockName + " for " + overrideSeconds + " seconds.");
                         break;
                     }
@@ -645,11 +649,15 @@ public class Wakelocks implements IXposedHookLoadPackage {
                 if (alarmWildcards != null) {
                     //For each wildcard block
                     for (String wildcard : alarmWildcards) {
-                        String regexToMatch = wildcard.substring(0, wildcard.indexOf("$$||$$"));
-                        if (alarmName.matches(wildcard)) {
+                        String[] values = wildcard.split("\\$\\$\\|\\|\\$\\$"); // matches $$||$$
+                        if (values.length < 2)
+                            continue;  // *should* never happen
+
+                        String regexToMatch = values[0];
+                        boolean disabled = values.length > 2 && "disabled".equals(values[2]);
+                        if (!disabled && alarmName.matches(regexToMatch)) {
                             block = true;
-                            overrideSeconds = Integer.parseInt(wildcard.substring(wildcard.indexOf("$$||$$") + 6));
-                            trackingAlarmName = wildcard;
+                            overrideSeconds = Integer.parseInt(values[1]);
                             debugLog("Regex set for Alarm: " + alarmName + " for " + overrideSeconds + " seconds.");
                             break;
                         }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/tasker/TaskerActivity.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/tasker/TaskerActivity.java
@@ -146,7 +146,7 @@ public class TaskerActivity extends Activity
                     taskerBundle.putString(BUNDLE_NAME, regexFragment.getName());
                     taskerBundle.putLong(BUNDLE_SECONDS, regexFragment.getSeconds());
                     taskerBundle.putBoolean(BUNDLE_ENABLED, regexFragment.getEnabled());
-                    blurb = regexFragment.getName() + " - " + (regexFragment.getEnabled() ?
+                    blurb = "Alarm: " + regexFragment.getName() + " - " + (regexFragment.getEnabled() ?
                             getResources().getString(R.string.tasker_on) :
                             getResources().getString(R.string.tasker_off)) +
                             " - " + regexFragment.getSeconds();
@@ -156,7 +156,7 @@ public class TaskerActivity extends Activity
                     taskerBundle.putString(BUNDLE_NAME, regexFragment.getName());
                     taskerBundle.putLong(BUNDLE_SECONDS, regexFragment.getSeconds());
                     taskerBundle.putBoolean(BUNDLE_ENABLED, regexFragment.getEnabled());
-                    blurb = regexFragment.getName() + " - " + (regexFragment.getEnabled() ?
+                    blurb = "Wakelock: " + regexFragment.getName() + " - " + (regexFragment.getEnabled() ?
                             getResources().getString(R.string.tasker_on) :
                             getResources().getString(R.string.tasker_off)) +
                             " - " + regexFragment.getSeconds();

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/tasker/TaskerActivity.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/tasker/TaskerActivity.java
@@ -70,6 +70,7 @@ public class TaskerActivity extends Activity
                         Log.d("Unbounce", "IAP inventory exists");
 
                         if (inventory.hasPurchase("donate_1") ||
+                                inventory.hasPurchase("donate_2") ||
                                 inventory.hasPurchase("donate_5") ||
                                 inventory.hasPurchase("donate_10")) {
                             Log.d("Unbounce", "IAP inventory contains a donation");
@@ -80,8 +81,6 @@ public class TaskerActivity extends Activity
                 }
             }
         };
-        // TODO: remove and actually fix this issue
-        mIsPremium = true;
 
         //Normally we would secure this key, but we're not licensing this app.
         String base64billing = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxwicOx54j03qBil36upqYab0uBWnf+WjoSRNOaTD9mkqj9bLM465gZlDXhutMZ+n5RlHUqmxl7jwH9KyYGTbwFqCxbLMCwR4oDhXVhX4fS6iggoHY7Ek6EzMT79x2XwCDg1pdQmX9d9TYRp32Sw2E+yg2uZKSPW29ikfdcmfkHcdCWrjFSuMJpC14R3d9McWQ7sg42eQq2spIuSWtP8ARGtj1M8eLVxgkQpXWrk9ijPgVcAbNZYWT9ndIZoKPg7VJVvzzAUNK/YOb+BzRurqJ42vCZy1+K+E4EUtmg/fxawHfXLZ3F/gNwictZO9fv1PYHPMa0sezSNVFAcm0yP1BwIDAQAB";

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/tasker/TaskerActivity.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/tasker/TaskerActivity.java
@@ -22,12 +22,15 @@ import com.ryansteckler.nlpunbounce.BaseDetailFragment;
 import com.ryansteckler.nlpunbounce.R;
 import com.ryansteckler.nlpunbounce.WakelockDetailFragment;
 import com.ryansteckler.nlpunbounce.WakelocksFragment;
+import com.ryansteckler.nlpunbounce.RegexDetailFragment;
+import com.ryansteckler.nlpunbounce.RegexFragment;
 
 public class TaskerActivity extends Activity
         implements
         WakelocksFragment.OnFragmentInteractionListener,
         BaseDetailFragment.FragmentInteractionListener,
         AlarmsFragment.OnFragmentInteractionListener,
+        RegexFragment.OnFragmentInteractionListener,
         TaskerWhichFragment.OnFragmentInteractionListener {
 
     public static final String EXTRA_BUNDLE = "com.twofortyfouram.locale.intent.extra.BUNDLE";
@@ -77,6 +80,8 @@ public class TaskerActivity extends Activity
                 }
             }
         };
+        // TODO: remove and actually fix this issue
+        mIsPremium = true;
 
         //Normally we would secure this key, but we're not licensing this app.
         String base64billing = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxwicOx54j03qBil36upqYab0uBWnf+WjoSRNOaTD9mkqj9bLM465gZlDXhutMZ+n5RlHUqmxl7jwH9KyYGTbwFqCxbLMCwR4oDhXVhX4fS6iggoHY7Ek6EzMT79x2XwCDg1pdQmX9d9TYRp32Sw2E+yg2uZKSPW29ikfdcmfkHcdCWrjFSuMJpC14R3d9McWQ7sg42eQq2spIuSWtP8ARGtj1M8eLVxgkQpXWrk9ijPgVcAbNZYWT9ndIZoKPg7VJVvzzAUNK/YOb+BzRurqJ42vCZy1+K+E4EUtmg/fxawHfXLZ3F/gNwictZO9fv1PYHPMa0sezSNVFAcm0yP1BwIDAQAB";
@@ -116,6 +121,8 @@ public class TaskerActivity extends Activity
                 String blurb = "";
 
                 WakelockDetailFragment wlFragment = (WakelockDetailFragment)fragmentManager.findFragmentByTag("wakelock_detail");
+                AlarmDetailFragment alarmFragment;
+                RegexDetailFragment regexFragment;
                 if (wlFragment != null) {
                     taskerBundle.putString(BUNDLE_TYPE, "wakelock");
                     taskerBundle.putString(BUNDLE_NAME, wlFragment.getName());
@@ -125,18 +132,34 @@ public class TaskerActivity extends Activity
                             getResources().getString(R.string.tasker_on) :
                             getResources().getString(R.string.tasker_off)) +
                             " - " + wlFragment.getSeconds();
+                } else if ((alarmFragment = (AlarmDetailFragment)fragmentManager.findFragmentByTag("alarm_detail")) != null) {
+                    taskerBundle.putString(BUNDLE_TYPE, "alarm");
+                    taskerBundle.putString(BUNDLE_NAME, alarmFragment.getName());
+                    taskerBundle.putLong(BUNDLE_SECONDS, alarmFragment.getSeconds());
+                    taskerBundle.putBoolean(BUNDLE_ENABLED, alarmFragment.getEnabled());
+                    blurb = alarmFragment.getName() + " - " + (alarmFragment.getEnabled() ?
+                            getResources().getString(R.string.tasker_on) :
+                            getResources().getString(R.string.tasker_off)) +
+                            " - " + alarmFragment.getSeconds();
+                } else if ((regexFragment = (RegexDetailFragment)fragmentManager.findFragmentByTag("regex_detail_alarm"))!= null) {
+                    taskerBundle.putString(BUNDLE_TYPE, "regex_alarm");
+                    taskerBundle.putString(BUNDLE_NAME, regexFragment.getName());
+                    taskerBundle.putLong(BUNDLE_SECONDS, regexFragment.getSeconds());
+                    taskerBundle.putBoolean(BUNDLE_ENABLED, regexFragment.getEnabled());
+                    blurb = regexFragment.getName() + " - " + (regexFragment.getEnabled() ?
+                            getResources().getString(R.string.tasker_on) :
+                            getResources().getString(R.string.tasker_off)) +
+                            " - " + regexFragment.getSeconds();
                 } else {
-                    AlarmDetailFragment alarmFragment = (AlarmDetailFragment)fragmentManager.findFragmentByTag("alarm_detail");
-                    if (alarmFragment != null) {
-                        taskerBundle.putString(BUNDLE_TYPE, "alarm");
-                        taskerBundle.putString(BUNDLE_NAME, alarmFragment.getName());
-                        taskerBundle.putLong(BUNDLE_SECONDS, alarmFragment.getSeconds());
-                        taskerBundle.putBoolean(BUNDLE_ENABLED, alarmFragment.getEnabled());
-                        blurb = alarmFragment.getName() + " - " + (alarmFragment.getEnabled() ?
-                                getResources().getString(R.string.tasker_on) :
-                                getResources().getString(R.string.tasker_off)) +
-                                " - " + alarmFragment.getSeconds();
-                    }
+                    regexFragment = (RegexDetailFragment)fragmentManager.findFragmentByTag("regex_detail_wakelock");
+                    taskerBundle.putString(BUNDLE_TYPE, "regex_wakelock");
+                    taskerBundle.putString(BUNDLE_NAME, regexFragment.getName());
+                    taskerBundle.putLong(BUNDLE_SECONDS, regexFragment.getSeconds());
+                    taskerBundle.putBoolean(BUNDLE_ENABLED, regexFragment.getEnabled());
+                    blurb = regexFragment.getName() + " - " + (regexFragment.getEnabled() ?
+                            getResources().getString(R.string.tasker_on) :
+                            getResources().getString(R.string.tasker_off)) +
+                            " - " + regexFragment.getSeconds();
                 }
 
                 final Intent resultIntent = new Intent();
@@ -216,6 +239,18 @@ public class TaskerActivity extends Activity
 
     @Override
     public void onAlarmsSetTaskerTitle(String title) {
+        TextView text = (TextView)findViewById(R.id.textTaskerHeader);
+        text.setText(title);
+        Button save = (Button)findViewById(R.id.buttonTaskerSave);
+        save.setVisibility(View.GONE);
+    }
+
+    @Override
+    public void onRegexSetTitle(String title) {
+    }
+
+    @Override
+    public void onRegexSetTaskerTitle(String title) {
         TextView text = (TextView)findViewById(R.id.textTaskerHeader);
         text.setText(title);
         Button save = (Button)findViewById(R.id.buttonTaskerSave);

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/tasker/TaskerReceiver.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/tasker/TaskerReceiver.java
@@ -5,9 +5,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.text.TextUtils;
 
 import com.ryansteckler.nlpunbounce.XposedReceiver;
 import com.ryansteckler.nlpunbounce.models.UnbounceStatsCollection;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Iterator;
 
 public class TaskerReceiver extends BroadcastReceiver {
     public TaskerReceiver() {
@@ -28,6 +33,30 @@ public class TaskerReceiver extends BroadcastReceiver {
                     } catch (IllegalStateException ise) {
 
                     }
+
+                } else if (type.startsWith("regex")) {
+                    long seconds = savedBundle.getLong(TaskerActivity.BUNDLE_SECONDS);
+                    boolean enabled = savedBundle.getBoolean(TaskerActivity.BUNDLE_ENABLED);
+                    String name = savedBundle.getString(TaskerActivity.BUNDLE_NAME);
+                    type = type.substring(type.indexOf("_") + 1);
+
+                    String blockName = name + "$$||$$" + Long.toString(seconds) + "$$||$$" + (enabled ? "enabled" : "disabled");
+
+                    //set the prefs appropriately.
+                    SharedPreferences prefs = context.getSharedPreferences("com.ryansteckler.nlpunbounce" + "_preferences", Context.MODE_WORLD_READABLE);
+                    Set<String> sampleSet = new HashSet<String>();
+                    Set<String> set = new HashSet<String>(prefs.getStringSet(type + "_regex_set", sampleSet));
+                    for (Iterator<String> i = set.iterator(); i.hasNext();) {
+                        String str = i.next();
+                        if (str.startsWith(name)) {
+                            i.remove();
+                        }
+                    }
+                    set.add(blockName);
+
+                    SharedPreferences.Editor editor = prefs.edit();
+                    editor.putStringSet(type + "_regex_set", set);
+                    editor.apply();
 
                 } else {
                     long seconds = savedBundle.getLong(TaskerActivity.BUNDLE_SECONDS);

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/tasker/TaskerReceiver.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/tasker/TaskerReceiver.java
@@ -48,7 +48,7 @@ public class TaskerReceiver extends BroadcastReceiver {
                     Set<String> set = new HashSet<String>(prefs.getStringSet(type + "_regex_set", sampleSet));
                     for (Iterator<String> i = set.iterator(); i.hasNext();) {
                         String str = i.next();
-                        if (str.startsWith(name)) {
+                        if (str.startsWith(name + "$$||$$")) {
                             i.remove();
                         }
                     }

--- a/app/src/main/java/com/ryansteckler/nlpunbounce/tasker/TaskerWhichFragment.java
+++ b/app/src/main/java/com/ryansteckler/nlpunbounce/tasker/TaskerWhichFragment.java
@@ -12,6 +12,8 @@ import android.widget.Button;
 import com.ryansteckler.nlpunbounce.AlarmsFragment;
 import com.ryansteckler.nlpunbounce.R;
 import com.ryansteckler.nlpunbounce.WakelocksFragment;
+import com.ryansteckler.nlpunbounce.WakelockRegexFragment;
+import com.ryansteckler.nlpunbounce.AlarmRegexFragment;
 
 /**
  * Created by rsteckler on 9/28/14.
@@ -68,6 +70,40 @@ public class TaskerWhichFragment extends Fragment {
 
                 if (mListener != null)
                     mListener.onTaskerWhichSetTitle(getResources().getString(R.string.tasker_choose_alarm));
+            }
+        });
+
+        button = (Button) view.findViewById(R.id.buttonTaskerWakelockRegex);
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                FragmentManager fragmentManager = getFragmentManager();
+                fragmentManager.beginTransaction()
+                        .setCustomAnimations(android.R.animator.fade_in, android.R.animator.fade_out, android.R.animator.fade_in, android.R.animator.fade_out)
+                        .hide(TaskerWhichFragment.this)
+                        .add(R.id.container, WakelockRegexFragment.newInstance(true))
+                        .addToBackStack(null)
+                        .commit();
+
+                if (mListener != null)
+                    mListener.onTaskerWhichSetTitle(getResources().getString(R.string.tasker_choose_wakelock_regex));
+            }
+        });
+
+        button = (Button) view.findViewById(R.id.buttonTaskerAlarmRegex);
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                FragmentManager fragmentManager = getFragmentManager();
+                fragmentManager.beginTransaction()
+                        .setCustomAnimations(android.R.animator.fade_in, android.R.animator.fade_out, android.R.animator.fade_in, android.R.animator.fade_out)
+                        .hide(TaskerWhichFragment.this)
+                        .add(R.id.container, AlarmRegexFragment.newInstance(true))
+                        .addToBackStack(null)
+                        .commit();
+
+                if (mListener != null)
+                    mListener.onTaskerWhichSetTitle(getResources().getString(R.string.tasker_choose_alarm_regex));
             }
         });
 

--- a/app/src/main/res/layout/fragment_regex_detail.xml
+++ b/app/src/main/res/layout/fragment_regex_detail.xml
@@ -1,0 +1,246 @@
+<com.ryansteckler.nlpunbounce.ExpandingLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:id="@+id/layoutDetails"
+    android:layout_height="match_parent"
+    tools:context="com.ryansteckler.nlpunbounce.AlarmDetailFragment"
+    android:visibility="visible"
+    android:background="?activityRootBackground">
+
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/scrollView">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:visibility="visible"
+            android:alpha="1">
+
+
+            <LinearLayout
+                android:orientation="vertical"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="?cardBackground"
+                android:layout_margin="@dimen/card_external_padding"
+                android:layout_marginTop="@dimen/activity_vertical_margin">
+
+                <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?background_four_shaded"
+                    android:paddingLeft="@dimen/card_internal_padding"
+                    android:paddingTop="@dimen/card_internal_padding"
+                    android:paddingBottom="@dimen/card_internal_padding"
+                    android:paddingRight="@dimen/card_internal_padding">
+
+                    <ImageView
+                        android:layout_width="@dimen/header_icon_size"
+                        android:layout_height="@dimen/header_icon_size"
+                        android:src="@drawable/ic_settings_four"
+                        android:contentDescription="@string/title_settings" />
+
+                    <LinearLayout
+                        android:orientation="vertical"
+                        android:layout_width="0dp"
+                        android:layout_height="fill_parent"
+                        android:gravity="center_vertical"
+                        android:layout_weight="1">
+
+                        <TextView
+                            android:id="@+id/lb_settings"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:enabled="false"
+                            android:layout_marginLeft="@dimen/pad_icon"
+                            android:layout_marginStart="@dimen/pad_icon"
+                            android:text="@string/card_settings_title"
+                            style="@style/TextTitleLight" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/card_settings_subtitle_alarm"
+                            android:layout_marginLeft="@dimen/pad_icon"
+                            android:layout_marginStart="@dimen/pad_icon"
+                            style="@style/TextCaptionLight" />
+
+                    </LinearLayout>
+
+                    <Switch
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/switchStat"
+                        android:alpha="1"/>
+
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:padding="@dimen/card_internal_padding"
+                    android:id="@+id/settingsPanelPattern"
+                    android:background="?background_panel_disabled"
+                    android:paddingLeft="1dp"
+                    android:paddingRight="1dp"
+                    android:paddingBottom="2dp" >
+
+                    <TextView
+                        style="?cardText"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:text="@string/settings_regex"
+                        android:layout_marginRight="@dimen/card_external_padding"
+                        android:layout_marginEnd="@dimen/card_external_padding"
+                        android:layout_weight=".25"
+                        android:layout_gravity="center_vertical" />
+
+                    <EditText
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:inputType="text"
+                        android:id="@+id/editRegex"
+                        android:layout_weight=".8"
+                        android:maxLength="7"
+                        android:maxLines="1"
+                        android:lines="1"
+                        android:textAlignment="center"
+                        android:gravity="center_horizontal"
+                        android:layout_gravity="center_horizontal" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                                android:orientation="horizontal"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center_vertical"
+                                android:padding="@dimen/card_internal_padding"
+                                android:id="@+id/settingsPanelSeconds"
+                                android:background="?background_panel_disabled"
+                                android:paddingLeft="1dp"
+                                android:paddingRight="1dp"
+                                android:paddingBottom="2dp">
+
+                                <TextView
+                                    android:layout_width="0dp"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/settings_allow_every"
+                                    style="?cardText"
+                                    android:layout_marginRight="@dimen/card_external_padding"
+                                    android:layout_marginEnd="@dimen/card_external_padding"
+                                    android:layout_weight=".25"
+                                    android:layout_gravity="center_vertical" />
+
+                                <EditText
+                                    android:layout_width="0dp"
+                                    android:layout_height="wrap_content"
+                                    android:inputType="number"
+                                    android:id="@+id/editAlarmSeconds"
+                                    android:layout_weight=".35"
+                                    android:maxLength="7"
+                                    android:maxLines="1"
+                                    android:lines="1"
+                                    android:textAlignment="center"
+                                    android:gravity="center_horizontal"
+                                    android:layout_gravity="center_horizontal" />
+
+                                <TextView
+                                    android:layout_width="0dp"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/settings_seconds"
+                                    style="?cardText"
+                                    android:layout_marginLeft="@dimen/card_external_padding"
+                                    android:layout_marginStart="@dimen/card_external_padding"
+                                    android:layout_weight=".45"
+                                    android:layout_gravity="center_vertical" />
+                            </LinearLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:orientation="vertical"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:background="?cardBackground"
+                android:layout_margin="@dimen/card_external_padding"
+                android:layout_marginTop="@dimen/activity_vertical_margin">
+
+                <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?background_four_shaded"
+                    android:paddingStart="@dimen/card_internal_padding"
+                    android:paddingEnd="@dimen/card_internal_padding"
+                    android:paddingLeft="@dimen/card_internal_padding"
+                    android:paddingRight="@dimen/card_internal_padding"
+                    android:paddingTop="@dimen/card_internal_padding"
+                    android:paddingBottom="@dimen/card_internal_padding">
+
+                    <ImageView
+                        android:layout_width="@dimen/header_icon_size"
+                        android:layout_height="@dimen/header_icon_size"
+                        android:src="@drawable/ic_description_four"
+                        android:contentDescription="@string/card_description_title" />
+
+                    <LinearLayout
+                        android:orientation="vertical"
+                        android:layout_width="0dp"
+                        android:layout_height="fill_parent"
+                        android:gravity="center_vertical"
+                        android:layout_weight="1">
+
+                        <TextView
+                            android:id="@+id/lb_description"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:enabled="false"
+                            android:layout_marginLeft="@dimen/pad_icon"
+                            android:layout_marginStart="@dimen/pad_icon"
+                            android:text="@string/card_description_title"
+                            style="@style/TextTitleLight" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/card_description_subtitle_regex"
+                            android:layout_marginLeft="@dimen/pad_icon"
+                            android:layout_marginStart="@dimen/pad_icon"
+                            style="@style/TextCaptionLight" />
+
+                    </LinearLayout>
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:orientation="vertical"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:padding="@dimen/card_internal_padding">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/desc_regex_unknown"
+                        style="?cardText"
+                        android:id="@+id/textViewDescription"
+                        android:alpha=".87" />
+
+                </LinearLayout>
+
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </ScrollView>
+</com.ryansteckler.nlpunbounce.ExpandingLayout>

--- a/app/src/main/res/layout/fragment_regex_detail.xml
+++ b/app/src/main/res/layout/fragment_regex_detail.xml
@@ -65,7 +65,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="@string/card_settings_subtitle_alarm"
+                            android:text="@string/card_settings_subtitle_regex"
                             android:layout_marginLeft="@dimen/pad_icon"
                             android:layout_marginStart="@dimen/pad_icon"
                             style="@style/TextCaptionLight" />
@@ -76,7 +76,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:id="@+id/switchStat"
-                        android:alpha="1"/>
+                        android:alpha="1"
+                        android:checked="false" />
 
 
                 </LinearLayout>
@@ -87,7 +88,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
                     android:padding="@dimen/card_internal_padding"
-                    android:id="@+id/settingsPanelPattern"
+                    android:id="@+id/settingsPanelRegex"
                     android:background="?background_panel_disabled"
                     android:paddingLeft="1dp"
                     android:paddingRight="1dp"
@@ -109,7 +110,6 @@
                         android:inputType="text"
                         android:id="@+id/editRegex"
                         android:layout_weight=".8"
-                        android:maxLength="7"
                         android:maxLines="1"
                         android:lines="1"
                         android:textAlignment="center"
@@ -144,7 +144,7 @@
                                     android:layout_width="0dp"
                                     android:layout_height="wrap_content"
                                     android:inputType="number"
-                                    android:id="@+id/editAlarmSeconds"
+                                    android:id="@+id/editRegexSeconds"
                                     android:layout_weight=".35"
                                     android:maxLength="7"
                                     android:maxLines="1"

--- a/app/src/main/res/layout/fragment_regex_listitem.xml
+++ b/app/src/main/res/layout/fragment_regex_listitem.xml
@@ -2,38 +2,72 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal"
+    android:orientation="vertical"
     android:clickable="false"
     android:background="?attr/listBackgroundAlarm"
     android:paddingTop="@dimen/separator_pad"
     android:paddingBottom="@dimen/separator_pad"
-    android:id="@+id/listitemAlarm"
-    android:baselineAligned="false"
-    android:descendantFocusability="blocksDescendants">
+    android:id="@+id/listitemAlarmDetail"
+    android:baselineAligned="false">
 
 
-    <TextView
-        android:id="@+id/textviewRegexName"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/stat_loading"
-        android:fontFamily="@string/app_font_family"
-        android:singleLine="true"
-        style="?cardText"
-        android:layout_marginLeft="@dimen/section_pad"
-        android:layout_marginStart="@dimen/section_pad"
-        android:ellipsize="end"
-        android:layout_weight="1"
-        android:layout_gravity="center_vertical" />
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="0px"
+        android:orientation="horizontal"
+        android:clickable="false"
+        android:background="?attr/listBackgroundAlarm"
+        android:paddingTop="@dimen/separator_pad"
+        android:paddingBottom="@dimen/separator_pad"
+        android:id="@+id/listitemAlarm"
+        android:baselineAligned="false"
+        android:descendantFocusability="blocksDescendants"
+        android:layout_weight=".5">
 
-    <Button
-        style="?android:attr/buttonStyleSmall"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="DELETE"
-        android:id="@+id/btn_delete_regex"
-        android:enabled="true"
-        android:layout_gravity="center_vertical" />
+        <TextView
+            android:id="@+id/textviewRegexName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/stat_loading"
+            android:fontFamily="@string/app_font_family"
+            android:singleLine="true"
+            style="?cardText"
+            android:layout_marginLeft="@dimen/section_pad"
+            android:layout_marginStart="@dimen/section_pad"
+            android:ellipsize="end"
+            android:layout_weight="1"
+            android:layout_gravity="center_vertical" />
+
+        <Button
+            style="?android:attr/buttonStyleSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="DELETE"
+            android:id="@+id/btn_delete_regex"
+            android:enabled="true"
+            android:layout_gravity="center_vertical" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="0px"
+        android:id="@+id/regexMatchList"
+        android:layout_weight=".5">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/alarm_regex_matches"
+            android:id="@+id/regexMatchText"
+            android:textStyle="italic"
+            style="?cardText"
+            android:layout_marginLeft="@dimen/section_pad"
+            android:ellipsize="marquee"
+            android:fontFamily="@string/app_font_family"
+            android:singleLine="true" />
+
+    </LinearLayout>
 
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_regex_listitem.xml
+++ b/app/src/main/res/layout/fragment_regex_listitem.xml
@@ -24,19 +24,41 @@
         android:descendantFocusability="blocksDescendants"
         android:layout_weight=".5">
 
-        <TextView
-            android:id="@+id/textviewRegexName"
+        <LinearLayout
+            android:orientation="vertical"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/stat_loading"
-            android:fontFamily="@string/app_font_family"
-            android:singleLine="true"
-            style="?cardText"
-            android:layout_marginLeft="@dimen/section_pad"
-            android:layout_marginStart="@dimen/section_pad"
-            android:ellipsize="end"
-            android:layout_weight="1"
-            android:layout_gravity="center_vertical" />
+            android:id="@+id/regexMatchList"
+            android:layout_weight=".5"
+            android:layout_gravity="center_vertical">
+
+            <TextView
+                android:id="@+id/textviewRegexName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/stat_loading"
+                android:fontFamily="@string/app_font_family"
+                android:singleLine="true"
+                style="?cardText"
+                android:layout_marginLeft="@dimen/section_pad"
+                android:layout_marginStart="@dimen/section_pad"
+                android:ellipsize="end"
+                android:layout_weight="1"
+                android:layout_gravity="center_vertical" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/regex_list_disabled"
+                android:id="@+id/regexMatchText"
+                android:textStyle="italic"
+                style="?cardText"
+                android:layout_marginLeft="@dimen/section_pad"
+                android:ellipsize="marquee"
+                android:fontFamily="@string/app_font_family"
+                android:singleLine="true"
+                android:layout_gravity="center_vertical" />
+        </LinearLayout>
 
         <Button
             style="?android:attr/buttonStyleSmall"
@@ -45,28 +67,7 @@
             android:text="DELETE"
             android:id="@+id/btn_delete_regex"
             android:enabled="true"
-            android:layout_gravity="center_vertical" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="0px"
-        android:id="@+id/regexMatchList"
-        android:layout_weight=".5">
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/alarm_regex_matches"
-            android:id="@+id/regexMatchText"
-            android:textStyle="italic"
-            style="?cardText"
-            android:layout_marginLeft="@dimen/section_pad"
-            android:ellipsize="marquee"
-            android:fontFamily="@string/app_font_family"
-            android:singleLine="true" />
-
+            android:layout_gravity="center_vertical|right" />
     </LinearLayout>
 
 

--- a/app/src/main/res/layout/fragment_tasker_which.xml
+++ b/app/src/main/res/layout/fragment_tasker_which.xml
@@ -38,6 +38,24 @@
             android:layout_marginTop="@dimen/card_external_padding" />
 
         <Button
+            style="@style/TextTitleLight"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/tasker_task_wakelock_regex"
+            android:id="@+id/buttonTaskerWakelockRegex"
+            android:layout_marginTop="@dimen/card_internal_padding"
+            android:background="@color/background_secondary" />
+
+        <Button
+            style="@style/TextTitleLight"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/tasker_task_alarm_regex"
+            android:id="@+id/buttonTaskerAlarmRegex"
+            android:background="@color/background_four"
+            android:layout_marginTop="@dimen/card_external_padding" />
+
+        <Button
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/tasker_task_reset"

--- a/app/src/main/res/layout/fragment_tasker_which.xml
+++ b/app/src/main/res/layout/fragment_tasker_which.xml
@@ -19,41 +19,57 @@
             style="@style/TextTitle"
             android:layout_marginBottom="@dimen/card_internal_padding" />
 
-        <Button
+        <LinearLayout
+            android:orientation="horizontal"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/tasker_task_wakelock"
-            android:id="@+id/buttonTaskerWakelock"
-            android:layout_marginTop="@dimen/card_internal_padding"
-            android:background="@color/background_secondary"
-            style="@style/TextTitleLight" />
+            android:layout_marginTop="@dimen/card_internal_padding">
 
-        <Button
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/tasker_task_alarm"
-            android:id="@+id/buttonTaskerAlarm"
-            android:background="@color/background_four"
-            style="@style/TextTitleLight"
-            android:layout_marginTop="@dimen/card_external_padding" />
+            <Button
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/tasker_task_wakelock"
+                android:id="@+id/buttonTaskerWakelock"
+                android:background="@color/background_secondary"
+                style="@style/TextTitleLight"
+                android:layout_weight=".3" />
 
-        <Button
-            style="@style/TextTitleLight"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/tasker_task_wakelock_regex"
-            android:id="@+id/buttonTaskerWakelockRegex"
-            android:layout_marginTop="@dimen/card_external_padding"
-            android:background="@color/background_secondary" />
+            <Button
+                style="@style/TextTitleLight"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/tasker_task_wakelock_regex"
+                android:id="@+id/buttonTaskerWakelockRegex"
+                android:background="@color/background_secondary"
+                android:layout_weight=".7"
+                android:layout_marginLeft="@dimen/card_external_padding" />
+        </LinearLayout>
 
-        <Button
-            style="@style/TextTitleLight"
+        <LinearLayout
+            android:orientation="horizontal"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/tasker_task_alarm_regex"
-            android:id="@+id/buttonTaskerAlarmRegex"
-            android:background="@color/background_four"
-            android:layout_marginTop="@dimen/card_external_padding" />
+            android:layout_marginTop="@dimen/card_external_padding">
+
+            <Button
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/tasker_task_alarm"
+                android:id="@+id/buttonTaskerAlarm"
+                android:background="@color/background_four"
+                style="@style/TextTitleLight"
+                android:layout_weight=".3" />
+
+            <Button
+                style="@style/TextTitleLight"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/tasker_task_alarm_regex"
+                android:id="@+id/buttonTaskerAlarmRegex"
+                android:background="@color/background_four"
+                android:layout_marginLeft="@dimen/card_external_padding"
+                android:layout_weight=".7" />
+        </LinearLayout>
 
         <Button
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_tasker_which.xml
+++ b/app/src/main/res/layout/fragment_tasker_which.xml
@@ -43,7 +43,7 @@
             android:layout_height="wrap_content"
             android:text="@string/tasker_task_wakelock_regex"
             android:id="@+id/buttonTaskerWakelockRegex"
-            android:layout_marginTop="@dimen/card_internal_padding"
+            android:layout_marginTop="@dimen/card_external_padding"
             android:background="@color/background_secondary" />
 
         <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,5 +216,6 @@ May you have a long [battery] life!
 <string name="service_switch_deny">"Deny"</string>
 <string name="action_new_custom_item">"New"</string>
     <string name="settings_scroll_item_names">Scroll Item Names</string>
+<string name="alarm_regex_matches">"Matches %1$d/%2$d alarms"</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
 <string name="card_settings_subtitle_wakelock">"Control this wakelock"</string>
 <string name="card_description_title">"DESCRIPTION"</string>
 <string name="card_description_subtitle">"Why is this thing eating your battery?"</string>
+<string name="card_description_subtitle_regex">"What will this do?"</string>
 <string name="category_unbounced">"Limited"</string>
 <string name="category_safe">"Safe to limit"</string>
 <string name="category_unknown">"Unknown"</string>
@@ -217,5 +218,8 @@ May you have a long [battery] life!
 <string name="action_new_custom_item">"New"</string>
     <string name="settings_scroll_item_names">Scroll Item Names</string>
 <string name="alarm_regex_matches">"Matches %1$d/%2$d alarms"</string>
+    <string name="desc_regex_unknown">"This pattern doesn't apply to any currently known alarms"</string>
+    <string name="desc_regex">"This pattern matches the following alarms (%1$d of %2$d):"</string>
+    <string name="settings_regex">"Pattern:"</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,8 +226,8 @@ May you have a long [battery] life!
 <string name="card_settings_subtitle_regex">"Control this regex"</string>
 <string name="tasker_task_wakelock_regex">"REGEX"</string>
 <string name="tasker_task_alarm_regex">"REGEX"</string>
-<string name="tasker_choose_alarm_regex">"Choose the alarm regex to adjust."</string>
-<string name="tasker_choose_wakelock_regex">"Choose the wakelock regex to adjust."</string>
+<string name="tasker_choose_alarm_regex">"Adjust an alarm regex."</string>
+<string name="tasker_choose_wakelock_regex">"Adjust a wakelock regex."</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,9 +217,11 @@ May you have a long [battery] life!
 <string name="service_switch_deny">"Deny"</string>
 <string name="action_new_custom_item">"New"</string>
     <string name="settings_scroll_item_names">Scroll Item Names</string>
-<string name="alarm_regex_matches">"Matches %1$d/%2$d alarms"</string>
-    <string name="desc_regex_unknown">"This pattern doesn't apply to any currently known alarms"</string>
-    <string name="desc_regex">"This pattern matches the following alarms (%1$d of %2$d):"</string>
-    <string name="settings_regex">"Pattern:"</string>
+<string name="regex_list_enabled">"Matches %1$d/%2$d events"</string>
+<string name="regex_list_disabled">"Pattern disabled"</string>
+<string name="desc_regex_unknown">"This pattern doesn't apply to any currently known events"</string>
+<string name="desc_regex">"This pattern matches %1$d of %2$d events:"</string>
+<string name="settings_regex">"Pattern:"</string>
+<string name="card_settings_subtitle_regex">"Control this regex"</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
 <string name="title_home">"Home"</string>
 <string name="title_wakelocks">"Wakelocks"</string>
 <string name="title_alarms">"Alarms"</string>
+<string name="title_regex">"Regex"</string>
 <string name="navigation_drawer_open">"Open navigation drawer"</string>
 <string name="navigation_drawer_close">"Close navigation drawer"</string>
 <string name="action_search">"Search"</string>
@@ -223,5 +224,10 @@ May you have a long [battery] life!
 <string name="desc_regex">"This pattern matches %1$d of %2$d events:"</string>
 <string name="settings_regex">"Pattern:"</string>
 <string name="card_settings_subtitle_regex">"Control this regex"</string>
+<string name="tasker_task_wakelock_regex">"CHANGE WAKELOCK (REGEX)"</string>
+<string name="tasker_task_alarm_regex">"CHANGE ALARM (REGEX)"</string>
+<string name="tasker_choose_alarm_regex">"Choose the alarm regex to adjust."</string>
+<string name="tasker_choose_wakelock_regex">"Choose the wakelock regex to adjust."</string>
+
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,8 +224,8 @@ May you have a long [battery] life!
 <string name="desc_regex">"This pattern matches %1$d of %2$d events:"</string>
 <string name="settings_regex">"Pattern:"</string>
 <string name="card_settings_subtitle_regex">"Control this regex"</string>
-<string name="tasker_task_wakelock_regex">"CHANGE WAKELOCK (REGEX)"</string>
-<string name="tasker_task_alarm_regex">"CHANGE ALARM (REGEX)"</string>
+<string name="tasker_task_wakelock_regex">"REGEX"</string>
+<string name="tasker_task_alarm_regex">"REGEX"</string>
 <string name="tasker_choose_alarm_regex">"Choose the alarm regex to adjust."</string>
 <string name="tasker_choose_wakelock_regex">"Choose the wakelock regex to adjust."</string>
 


### PR DESCRIPTION
Some improvements:
1. Regex creation/info follows the look & feel of the rest of the app with a detail view, similar to when an alarm/wakelock/service is clicked
2. Regex fragment code has been consolidated
3. Regex blocks can be enabled/disabled without removal
4. A description of the regex, consisting of which alarms/wakelocks it will apply to helps the user to prevent bugs in complex patterns
5. Tasker plugin supports regex modification (this required a UI change to the tasker_which layout which I think looks reasonable)

Some minor bugs were also fixed:
1. The Tasker plugin missed the $2 donation amount (probably the cause of issue #112)
2. Changing fragments with the navigation bar sometimes kept menu items from a previous fragment (this happened a lot when navigating from the regex list)
3. Service blocking doesn't support regex, so I disabled the menu button in that fragment

Since regex enabling/disabling required (minor) changes to the preference file, the code was written in a way to read either the new or old version but I forgot to test this thoroughly.
